### PR TITLE
モバイルでのフォントサイズの調整

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -650,7 +650,7 @@ body.standalone #help-modal {
     }
 }
 
-@media(max-width: 373px) {
+@media (max-width: 373px) {
   blockquote {
     font-size: 11px;
     p {

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -641,6 +641,17 @@ body.standalone #help-modal {
         font-size: 18px;
     }
 }
+@media (max-width: 390px) {
+    blockquote {
+        font-size: 11px;
+        p {
+            font-size: 14px;
+            &.tweet-date {
+                font-size: 12.25px;
+            }
+        }
+    }
+}
 @media (max-width: 382px) {
     ul.nav > li > a {
         padding: 12px 13px;
@@ -648,16 +659,4 @@ body.standalone #help-modal {
     #statistics-title {
         font-size: 22px;
     }
-}
-
-@media (max-width: 373px) {
-  blockquote {
-    font-size: 11px;
-    p {
-      font-size: 14px;
-      &.tweet-date  {
-        font-size: 12.25px;
-      }
-    }
-  }
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -289,7 +289,7 @@ blockquote {
             color: #697882;
             text-decoration: none;
             &:hover {
-                color: #927099; 
+                color: #927099;
             }
         }
     }
@@ -648,4 +648,16 @@ body.standalone #help-modal {
     #statistics-title {
         font-size: 22px;
     }
+}
+
+@media(max-width: 373px) {
+  blockquote {
+    font-size: 11px;
+    p {
+      font-size: 14px;
+      &.tweet-date  {
+        font-size: 12.25px;
+      }
+    }
+  }
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -641,7 +641,15 @@ body.standalone #help-modal {
         font-size: 18px;
     }
 }
-@media (max-width: 390px) {
+@media (max-width: 382px) {
+    ul.nav > li > a {
+        padding: 12px 13px;
+    }
+    #statistics-title {
+        font-size: 22px;
+    }
+}
+@media (max-width: 373px) {
     blockquote {
         font-size: 11px;
         p {
@@ -650,13 +658,5 @@ body.standalone #help-modal {
                 font-size: 12.25px;
             }
         }
-    }
-}
-@media (max-width: 382px) {
-    ul.nav > li > a {
-        padding: 12px 13px;
-    }
-    #statistics-title {
-        font-size: 22px;
     }
 }


### PR DESCRIPTION
幅373px以下でフォントサイズが全体的に小さくなるようになっていたが消去済ツイートではそれに追従出来ていなかった。

before
![](http://puu.sh/i5VfX/1923941878.png)

after
![](http://puu.sh/i5Vhl/43228021e9.png)
