### PR TITLE
Override `max-width: 520px` on .EmbeddedTweet

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -951,6 +951,7 @@ module RecoTwExplorer {
                     $contents.find(".Tweet-brand .u-hiddenInNarrowEnv").hide();
                     $contents.find(".Tweet-brand .u-hiddenInWideEnv").css("display", "inline-block");
                     $contents.find(".Tweet-author").css("max-width", "none");
+                    $contents.find(".EmbeddedTweet").css("max-width", "100%");
                 }
             });
         }


### PR DESCRIPTION
埋め込みツイートが仕様変更により最大幅520pxになっていたのへの対処

備考: masterにcherry-pickしてもいいかも
