### PR TITLE
Close #109: Fix layout issues in new Twitter embed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
     "multiline-comment-style": "off",
     "multiline-ternary": "off",
     "new-cap": "off",
+    "newline-per-chained-call": "off",
     "no-continue": "off",
     "no-confusing-arrow": "off",
     "no-console": "off",

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -4,12 +4,14 @@ $fa-font-path: "~font-awesome/fonts";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap";
 @import "~font-awesome/scss/font-awesome";
 
+html, body {
+    margin: 0;
+    padding: 0;
+}
 body {
     margin-top: 70px;
-    margin-bottom: 55px;
     background: #efefef;
     -webkit-text-size-adjust: 100%;
-    -ms-overflow-style: scrollbar;
     &.standalone {
         margin-top: 90px;
     }
@@ -227,28 +229,33 @@ blockquote, .twitter-tweet-rendered {
     position: static !important;
     display: block !important;
     margin: 20px auto !important;
-    width: 640px !important;
+    width: 550px !important;
     min-height: 80px !important;
     max-width: 100% !important;
 }
 blockquote {
-    font: normal normal 14px/1.2 Helvetica, Roboto, "Segoe UI", Calibri, sans-serif;
-    padding: 15px 20px 18px;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+    font-size: 15px;
+    padding: 15px 15px 10px;
     text-align: center;
     background: white;
-    border: 1px solid #e1e8ed;
-    border-radius: 4px;
-    a {
+    color: #657786;
+    border: 1px solid #ccd6dd;
+    border-radius: 14px;
+    a, a:hover {
         -webkit-tap-highlight-color: initial;
+        color: #1b95e0;
     }
     hr {
+        border-color: #ccd6dd;
         margin: 10px 0 15px;
     }
     div {
         text-align: left;
     }
-    span a {
-        color: #697882;
+    span a, span a:hover {
+        font-size: 15px;
+        color: #657786;
     }
     img {
         width: 24px;
@@ -257,18 +264,19 @@ blockquote {
         border-radius: 50%;
     }
     p {
-        font-size: 16px;
+        font-size: 19px;
         margin: 9px 0 6px 0;
-        word-break: break-all;
+        color: #14171a;
+        overflow-wrap: break-word;
     }
     .tweet-date {
-        font-size: 14px;
+        font-size: 15px;
         margin-top: 0;
         a {
-            color: #697882;
+            color: #657786;
             text-decoration: none;
             &:hover {
-                color: #927099;
+                text-decoration: underline;
             }
         }
     }
@@ -568,13 +576,7 @@ blockquote {
         margin-top: -14px;
     }
     blockquote {
-        font-size: 12px;
-        p {
-            font-size: 16px;
-        }
-        span a {
-            font-size: 12px;
-        }
+        font-size: 11px;
     }
     #statistics-tab {
         padding: 0 12px;
@@ -630,12 +632,6 @@ blockquote {
 @media (max-width: 373px) {
     blockquote {
         font-size: 11px;
-        p {
-            font-size: 14px;
-            &.tweet-date {
-                font-size: 12.25px;
-            }
-        }
     }
 }
 @media (max-width: 320px) {

--- a/src/ts/controller.ts
+++ b/src/ts/controller.ts
@@ -82,6 +82,9 @@ export class Controller {
         $window.on("orientationchange", () => {
             $(document.body).toggleClass("standalone", Boolean(navigator.standalone));
         }).trigger("orientationchange");
+        $window.on("resize", () => {
+            $("[id^='twitter-widget-']").width($("#main-area").width() ?? "");
+        });
         $window.on("scroll", () => {
             const height = Number($(document).height());
             const position = Number($window.height()) + Number($window.scrollTop());

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,5 @@
 import "../scss/style.scss";
+import "sffjs/cultures/stringformat.ja";
 import { Controller } from "./controller";
 
 Controller.main();

--- a/src/ts/resources.ts
+++ b/src/ts/resources.ts
@@ -9,7 +9,7 @@ export const FAILED_TO_GENERATE_PROFILE_IMAGE_URL = "プロフィール画像の
 export const FAILED_TO_LOAD_EMBEDDED_TWEET = "Twitter 埋め込みツイートの読み込みに失敗しました";
 export const SEARCH_HELP_HTML = "<dl><dt>ツイート検索</dt><dd><code>/</code> と <code>/</code> で囲むと正規表現検索</dd><dt>ユーザー名検索</dt><dd><code>from:</code> でユーザーを検索<br>カンマ区切りで複数入力</dd><dt>ID 検索</dt><dd><code>id:</code> で ID 検索</dd></dl>";
 export const STATISTICS_TABLE_HTML = "<span class=\"statistics-table-header\" style=\"border-color: #{0:X6};\"><a href=\"{4}\">{1}</a> ({2})&nbsp;&nbsp;&ndash;&nbsp;&nbsp;{3:P1}</span><br>";
-export const TWEET_TIME_HTML = "<a href=\"{0}\" target=\"_blank\"><time datetime=\"{2}\" title=\"投稿時刻: {1:U} (UTC)\">{1:yyyy年M月d日 HH:mm}</time></a>";
+export const TWEET_TIME_HTML = "<a href=\"{0}\" target=\"_blank\"><time datetime=\"{2}\">{1:tth:mm} · {1:D}</time></a>";
 export const TWEET_REMOVED_HTML = "<blockquote>ツイートは削除されたか、または非公開に設定されています。<hr><div><img src=\"{0}\"><span><a href=\"{1}\" target=\"_blank\">@{2}</a></span><p>{3}</p><p class=\"tweet-date\">{4}</p></div></blockquote>";
 export const LINK_TO_URL_HTML = "<a href=\"{0}\" target=\"_blank\">{0}</a>";
 export const URL_INPUT_REGEX = /^(?:(?:https?:\/\/(?:www\.|mobile\.)?)?twitter\.com\/(?:#!\/)?[a-zA-Z0-9_]+\/status(?:es)?\/(\d+)|(\d+))$/u;

--- a/src/ts/tab.ts
+++ b/src/ts/tab.ts
@@ -108,17 +108,11 @@ export class HomeTab extends Tab {
         twttr.ready(twttr => {
             twttr.widgets.createTweet(entry.tweet_id, $element[0], {
                 lang: "ja",
-                linkColor: "#774c80",
             }).then((widget?: HTMLElement): void => {
                 if (!widget) {
                     HomeTab.showStatusLoadFailedMessage(entry, $element);
                 } else {
-                    const $contents = $(widget.shadowRoot ?? widget).css("height", "auto")
-                        .contents();
-                    $contents.find(".Tweet-brand .u-hiddenInNarrowEnv").hide();
-                    $contents.find(".Tweet-brand .u-hiddenInWideEnv").css("display", "inline-block");
-                    $contents.find(".Tweet-author").css("max-width", "none");
-                    $contents.find(".EmbeddedTweet").css("max-width", "100%");
+                    $(widget).find("[data-tweet-id]").width($container.width() ?? "");
                 }
             });
         });


### PR DESCRIPTION
幅は 550px が最大となったため 640px 表示は諦めた。
コンテナーの幅が変わったときに埋め込みの幅が追従されないためイベントリスナーを追加。
表示できないツイート（404）のデザインを新しいものに適当に合わせた。

<img src="https://user-images.githubusercontent.com/6535425/86516875-51193b00-be5f-11ea-8f7a-f8d2aa326557.png" alt="" width="608">
