### PR TITLE
Update layout so Twitter embed detects container

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -226,16 +226,13 @@ ul.nav>li>a {
     margin: -8px -4px 0 0;
 }
 blockquote, .twitter-tweet-rendered {
-    position: static !important;
-    display: block !important;
     margin: 20px auto !important;
-    width: 550px !important;
-    min-height: 80px !important;
-    max-width: 100% !important;
 }
 blockquote {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
     font-size: 15px;
+    width: 550px;
+    max-width: 100%;
     padding: 15px 15px 10px;
     text-align: center;
     background: white;

--- a/src/ts/controller.ts
+++ b/src/ts/controller.ts
@@ -82,9 +82,6 @@ export class Controller {
         $window.on("orientationchange", () => {
             $(document.body).toggleClass("standalone", Boolean(navigator.standalone));
         }).trigger("orientationchange");
-        $window.on("resize", () => {
-            $("[id^='twitter-widget-']").width($("#main-area").width() ?? "");
-        });
         $window.on("scroll", () => {
             const height = Number($(document).height());
             const position = Number($window.height()) + Number($window.scrollTop());

--- a/src/ts/tab.ts
+++ b/src/ts/tab.ts
@@ -98,7 +98,7 @@ export class HomeTab extends Tab {
             $container = $main;
         }
 
-        twttr.ready(() => entries?.forEach(x => HomeTab.renderTweet(x, $container)));
+        entries?.forEach(x => HomeTab.renderTweet(x, $container));
         this._current += count ?? HomeTab.TWEETS_COUNT;
         super.render();
     }
@@ -111,8 +111,6 @@ export class HomeTab extends Tab {
             }).then((widget?: HTMLElement): void => {
                 if (!widget) {
                     HomeTab.showStatusLoadFailedMessage(entry, $element);
-                } else {
-                    $(widget).find("[data-tweet-id]").width($container.width() ?? "");
                 }
             });
         });

--- a/src/ts/tab.ts
+++ b/src/ts/tab.ts
@@ -66,7 +66,7 @@ export class Tab {
  * The home tab.
  */
 export class HomeTab extends Tab {
-    private static readonly TWEETS_COUNT = 25;
+    private static readonly TWEETS_COUNT = 10;
 
     private _current = 0;
 


### PR DESCRIPTION
* Twitter 埋め込みが行われる要素にスタイル指定をしていると幅の計算が正しく行われないことがわかったため修正
* リサイズ処理は上記処理の影響を受けていただけで Twitter 埋め込み側で処理されていたため削除
* 一画面あたりのツイートの表示数が多すぎると露骨にパフォーマンスが悪化するため 10 に変更